### PR TITLE
Remove instance of _swapFluxParam

### DIFF
--- a/armi/physics/fuelCycle/fuelHandlerInterface.py
+++ b/armi/physics/fuelCycle/fuelHandlerInterface.py
@@ -15,7 +15,6 @@
 """A place for the FuelHandler's Interface"""
 
 
-
 from armi import interfaces, runLog
 from armi.utils import plotting
 from armi.physics.fuelCycle import fuelHandlerFactory

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1171,7 +1171,6 @@ class FuelHandler:
             a1StationaryBlocks, oldA1Location, a2StationaryBlocks, oldA2Location
         )
 
-        self._swapFluxParam(a1, a2)
 
     def _validateAssemblySwap(
         self, a1StationaryBlocks, oldA1Location, a2StationaryBlocks, oldA2Location

--- a/armi/physics/fuelCycle/fuelHandlers.py
+++ b/armi/physics/fuelCycle/fuelHandlers.py
@@ -1167,7 +1167,6 @@ class FuelHandler:
         a1.moveTo(oldA2Location)
         a2.moveTo(oldA1Location)
 
-
         self._validateAssemblySwap(
             a1StationaryBlocks, oldA1Location, a2StationaryBlocks, oldA2Location
         )
@@ -1192,7 +1191,6 @@ class FuelHandler:
                             block, oldLocation, block.parent.spatialLocator
                         )
                     )
-
 
     def _transferStationaryBlocks(self, assembly1, assembly2):
         """
@@ -1241,7 +1239,6 @@ class FuelHandler:
         return [item[0] for item in a1StationaryBlocks], [
             item[0] for item in a2StationaryBlocks
         ]
-
 
     def dischargeSwap(self, incoming, outgoing):
         r"""

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -870,7 +870,6 @@ class TestFuelHandler(ArmiTestHelper):
         a1 = self.r.core.getAssemblies(Flags.FUEL)[0]
         a2 = self.r.core.sfp.getChildren(Flags.FUEL)[0]
 
-
         # move location of a stationary flag in assembly 1
         for block in a1:
             if any(block.hasFlags(sbf) for sbf in sBFList):
@@ -901,7 +900,6 @@ class TestFuelHandler(ArmiTestHelper):
                         )
                     )
                 break
-
 
         # try to discharge assembly 1 and replace with assembly 2
         with self.assertRaises(ValueError):

--- a/armi/reactor/reactors.py
+++ b/armi/reactor/reactors.py
@@ -2304,7 +2304,6 @@ class Core(composites.Composite):
 
         # Generate list of flags that are to be stationary during assembly shuffling
 
-
         if len(cs["stationaryBlocks"]) >= 1:
             self.ValueError(
                 "stationaryBlocks setting is deprecated. Use stationaryBlocksFlags."
@@ -2314,7 +2313,6 @@ class Core(composites.Composite):
 
         for stationaryBlockFlagString in cs["stationaryBlockFlags"]:
             stationaryBlockFlags.append(Flags.fromString(stationaryBlockFlagString))
-
 
         self.stationaryBlockFlagsList = stationaryBlockFlags
 

--- a/armi/settings/fwSettings/globalSettings.py
+++ b/armi/settings/fwSettings/globalSettings.py
@@ -661,7 +661,6 @@ def defineSettings() -> List[setting.Setting]:
             label="stationary Block Flags",
             description="Blocks with these flags will not move in moves. "
             "Used for fuel management.",
-
         ),
         setting.Setting(
             CONF_STATIONARY_BLOCKS,
@@ -670,7 +669,6 @@ def defineSettings() -> List[setting.Setting]:
             description="Blocks with these indices (int values) will not move in "
             "moves. Used for fuel management. "
             "Deprecated setting, use CONF_STATIONARY_BLOCK_FLAGS",
-
         ),
         setting.Setting(
             CONF_TARGET_K,


### PR DESCRIPTION
## Description

<!-- Mandatory: Please include a summary of the change and link to any related GitHub Issues.-->

---

## Checklist

<!--
    You (the pull requester) should put an `x` in the boxes below you have completed.
    If you're unsure about any of them, don't hesitate to ask. We're here to help!
    Learn what a "good PR" looks like here: https://terrapower.github.io/armi/developer/tooling.html#good-pull-requests
-->

- [ ] This PR has only one purpose or idea.
- [ ] Tests have been added/updated to verify that the new/changed code works.

<!-- Check the code quality -->

- [ ] The code style follows [good practices](https://terrapower.github.io/armi/developer/standards_and_practices.html).
- [ ] The commit message(s) follow [good practices](https://terrapower.github.io/armi/developer/tooling.html).

<!-- Check the project-level cruft -->

- [ ] The [release notes](https://terrapower.github.io/armi/release/index.html) are up-to-date with any bug fixes or new features.
- [ ] The documentation is still up-to-date in the `doc` folder.
- [ ] The dependencies are still up-to-date in `setup.py`.

