### PR TITLE
Add explicit rotation handling for YAML shuffles

### DIFF
--- a/armi/cases/case.py
+++ b/armi/cases/case.py
@@ -168,6 +168,12 @@ class Case:
                     r"^(?P<dirName>.*[\/\\])?(?P<title>[^\/\\]+)-SHUFFLES\.txt$",
                 )
             )
+            dependencies.update(
+                self.getPotentialParentFromSettingValue(
+                    self.cs["explicitRepeatShuffles"],
+                    r"^(?P<dirName>.*[\/\\])?(?P<title>[^\/\\]+)-SHUFFLES\.ya?ml$",
+                )
+            )
         # ensure that a case doesn't appear to be its own dependency
         dependencies.update(self._dependencies)
         dependencies.discard(self)

--- a/armi/cases/tests/test_cases.py
+++ b/armi/cases/tests/test_cases.py
@@ -385,6 +385,10 @@ class TestCaseSuiteDependencies(unittest.TestCase):
         self.c2.cs = self.c2.cs.modified(newSettings=newSettings)
         self.assertIn(self.c1, self.c2.dependencies)
 
+        newSettings = {"explicitRepeatShuffles": "c1-SHUFFLES.yaml"}
+        self.c2.cs = self.c2.cs.modified(newSettings=newSettings)
+        self.assertIn(self.c1, self.c2.dependencies)
+
     def test_explicitDependency(self):
         """
         Test dependencies for case suites.

--- a/armi/physics/fuelCycle/tests/test_fuelHandlers.py
+++ b/armi/physics/fuelCycle/tests/test_fuelHandlers.py
@@ -547,6 +547,52 @@ class TestFuelHandler(FuelHandlerTestHelper):
         with self.assertRaises(RuntimeError):
             fh.readMoves("totall_fictional_file.txt")
 
+    def test_readMovesYaml(self):
+        fh = fuelHandlers.FuelHandler(self.o)
+        moves = fh.readMovesYaml("armiRun-SHUFFLES.yaml")
+        self.maxDiff = None
+        expected = {
+            1: [
+                ("LoadQueue", "009-045", [0.0, 12.0, 14.0, 15.0, 0.0], "Type 1 outer fuel", None),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "007-001", [], None, None),
+                ("007-001", "006-005", [], None, None),
+                ("006-005", "SFP", [], None, None),
+                ("009-045", "009-045", [], None, None, 60.0),
+                ("LoadQueue", "010-046", [0.0, 12.0, 14.0, 15.0, 0.0], "Type 1 outer fuel", None),
+                ("010-046", "009-045", [], None, None),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "007-001", [], None, None),
+                ("007-001", "SFP", [], None, None),
+            ],
+            2: [
+                ("LoadQueue", "009-045", [0.0, 12.0, 14.0, 15.0, 0.0], "Type 1 outer fuel", None),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "007-001", [], None, None),
+                ("007-001", "006-005", [], None, None),
+                ("006-005", "SFP", [], None, None),
+                ("009-045", "009-045", [], None, None, 60.0),
+                ("LoadQueue", "010-046", [0.0, 12.0, 14.0, 15.0, 0.0], "Type 1 outer fuel", None),
+                ("010-046", "009-045", [], None, None),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "007-001", [], None, None),
+                ("007-001", "SFP", [], None, None),
+            ],
+            3: [
+                ("LoadQueue", "009-045", [0.0, 12.0, 14.0, 15.0, 0.0], "Type 1 outer fuel", None),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "007-001", [], None, None),
+                ("007-001", "006-005", [], None, None),
+                ("006-005", "SFP", [], None, None),
+                ("009-045", "009-045", [], None, None, 60.0),
+                ("009-045", "008-004", [], None, None),
+                ("008-004", "009-045", [], None, None),
+                ("008-004", "009-045", [], None, None),
+                ("009-045", "008-004", [], None, None),
+            ],
+        }
+        self.assertEqual(moves, expected)
+
     def test_processMoveList(self):
         fh = fuelHandlers.FuelHandler(self.o)
         moves = fh.readMoves("armiRun-SHUFFLES.txt")
@@ -556,6 +602,7 @@ class TestFuelHandler(FuelHandlerTestHelper):
             _,
             _,
             loadNames,
+            rotations,
             _,
         ) = fh.processMoveList(moves[2])
         self.assertIn("A0073", loadNames)
@@ -563,6 +610,15 @@ class TestFuelHandler(FuelHandlerTestHelper):
         self.assertNotIn("SFP", loadChains)
         self.assertNotIn("LoadQueue", loadChains)
         self.assertFalse(loopChains)
+        self.assertFalse(rotations)
+
+    def test_processMoveList_yaml(self):
+        fh = fuelHandlers.FuelHandler(self.o)
+        moves = fh.readMovesYaml("armiRun-SHUFFLES.yaml")
+        loadChains, loopChains, enriches, loadTypes, loadNames, rotations, _ = fh.processMoveList(moves[1])
+        self.assertEqual(len(loadChains), 2)
+        self.assertTrue(any(enriches))
+        self.assertTrue(rotations)
 
     def test_getFactorList(self):
         fh = fuelHandlers.FuelHandler(self.o)

--- a/armi/tests/armiRun-SHUFFLES.yaml
+++ b/armi/tests/armiRun-SHUFFLES.yaml
@@ -1,0 +1,14 @@
+sequence:
+  1: &cycle_1
+    - &shuffle_1_9_45
+      cascade: ["Type 1 outer fuel", "009-045", "008-004", "007-001", "006-005"]
+      fuelEnrichment: [0, 12, 14, 15, 0]
+      rotations: {"009-045": 60}
+    - cascade: ["Type 1 outer fuel", "010-046", "009-045", "008-004", "007-001"]
+      fuelEnrichment: [0, 12, 14, 15, 0]
+      rotations: {}
+  2: *cycle_1
+  3:
+    - *shuffle_1_9_45
+    - misloadSwap: ["009-045", "008-004"]
+    - misloadSwap: ["008-004", "009-045"]

--- a/doc/user/inputs.rst
+++ b/doc/user/inputs.rst
@@ -368,6 +368,24 @@ A few examples of restart cases:
 
 .. note:: The X-SHUFFLES.txt file is required to do explicit repeated fuel management.
 
+   The shuffling history can also be provided in a YAML file with the
+   ``*-SHUFFLES.yaml`` naming convention. The YAML format organizes
+   data by cycle in a ``sequence`` mapping. Each cycle contains a list of
+   high-level shuffle actions such as ``cascade`` chains, ``rotations``,
+   and ``misloadSwap`` entries. Cascades describe a new assembly type
+   moving through a series of locations until discharge. Optional
+   ``fuelEnrichment`` lists can specify the enrichment distribution for
+   the fresh assembly. ``rotations`` provide degrees of clockwise rotation
+   to apply after all moves in that cycle. For example::
+
+       sequence:
+        1:
+          - cascade: ["Type 1 outer fuel", "009-045", "008-004"]
+            fuelEnrichment: [0, 12, 14, 15, 0]
+            rotations: {"009-045": 60}
+        2: *1
+
+
 .. note:: The restart.dat file is required to repeat the exact fuel management methods during a branch search. These can potentially modify the reactor state in ways that cannot be captures with the SHUFFLES.txt file.
 
 .. note:: The ISO binary cross section libraries are required to run cases that skip the lattice physics calculation (e.g. MC^2)


### PR DESCRIPTION
## Summary
- support per-location rotation angles in YAML shuffle files
- propagate rotation info through `processMoveList`
- apply manual rotations after repeat shuffling
- document rotation syntax in YAML format

## Testing
- `ruff check armi/physics/fuelCycle/fuelHandlers.py armi/physics/fuelCycle/tests/test_fuelHandlers.py armi/cases/case.py`
- `pytest armi/physics/fuelCycle/tests/test_fuelHandlers.py::TestFuelHandler::test_readMovesYaml armi/cases/tests/test_cases.py::TestCaseSuiteDependencies::test_dependencyFromExplictRepeatShuffles armi/physics/fuelCycle/tests/test_fuelHandlers.py::TestFuelHandler::test_processMoveList_yaml -q`

------
https://chatgpt.com/codex/tasks/task_e_687fef0ab99083219c300ba3ab91c4de